### PR TITLE
Add 'executable' attr to the installer rule

### DIFF
--- a/src/installer.bash.template
+++ b/src/installer.bash.template
@@ -34,14 +34,15 @@ declare -r -a SOURCE_FILES=@@SOURCE_FILES@@
 declare -r -a TARGET_NAMES=@@TARGET_NAMES@@
 # Value for the -c or --compilation_mode bazel var.
 declare -r COMPILATION_MODE=@@COMPILATION_MODE@@
+# Set executable mode of files
+declare -r EXECUTABLE=@@EXECUTABLE@@
 # Fully specified bazel label of INSTALLER_LABEL installer() rule.
 declare -r INSTALLER_LABEL=@@INSTALLER_LABEL@@
-
 # Number of files.
 declare -r -i N_FILES="${#SOURCE_FILES[@]}"
 
 function error() {
-  echo >&2 "ERROR: $@"
+  echo >&2 "installer.bash ERROR: $@"
   usage
   exit 1
 }
@@ -83,10 +84,18 @@ function install_file() {
   target_dir="$(dirname -- "${prefix}/${target}")"
   local target_name
   target_name="$(basename -- "${target}")"
+  local target_mode
+  if [[ "${EXECUTABLE}" = "True" ]]; then
+    target_mode=755
+  else
+    target_mode=644
+  fi
 
-  [[ -d "${target_dir}" ]] ||
-    mkdir -p -- "${target_dir}"
-  cp -p -L -T -- "${source}" "${target_dir}/${target_name}"
+  [[ -d "${target_dir}" ]] || \
+    mkdir --parents -- "${target_dir}"
+
+  install --mode="${target_mode}" \
+    -T -- "${source}" "${target_dir}/${target_name}"
 }
 
 function main() {

--- a/src/installer.bzl
+++ b/src/installer.bzl
@@ -41,6 +41,7 @@ def _gen_install_binary_impl(ctx):
             "@@SOURCE_FILES@@": shell.array_literal(sources),
             "@@TARGET_NAMES@@": shell.array_literal(targets),
             "@@COMPILATION_MODE@@": shell.quote(ctx.var["COMPILATION_MODE"]),
+            "@@EXECUTABLE@@": shell.quote(repr(ctx.attr.executable)),
             "@@INSTALLER_LABEL@@": shell.quote("@{}//{}:{}".format(
                 ctx.workspace_name,
                 ctx.label.package,
@@ -68,6 +69,7 @@ _gen_installer = rule(
             mandatory = True,
             allow_files = True,
         ),
+        "executable": attr.bool(default = True),
         "target_subdir": attr.string(default = ""),
         "_template": attr.label(
             allow_single_file = True,
@@ -80,7 +82,7 @@ _gen_installer = rule(
     },
 )
 
-def installer(name, data, target_subdir = ""):
+def installer(name, data, executable = True, target_subdir = ""):
     """Creates an installer
 
     This rule creates an installer for targets in data. Running the installer
@@ -90,6 +92,7 @@ def installer(name, data, target_subdir = ""):
     Args:
       name: A unique name of this rule.
       data: Targets to be installed. File names will not be changed.
+      executable: If True (default), the copied files will be set as executable.
       target_subdir: Optional subdir under the prefix where the files will be
                      placed.
     """
@@ -97,6 +100,7 @@ def installer(name, data, target_subdir = ""):
     _gen_installer(
         name = installer_name,
         data = data,
+        executable = executable,
         target_subdir = target_subdir,
     )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -19,6 +19,7 @@ licenses(["notice"])  # Apache 2.0
 installer(
     name = "installer_under_test",
     data = ["testdata/data.txt"],
+    executable = False,
 )
 
 sh_test(
@@ -27,6 +28,7 @@ sh_test(
     args = [
         "$(location :installer_under_test)",
         "$(location testdata/data.txt)",
+        "-executable=False",
     ],
     data = [
         "testdata/data.txt",
@@ -45,6 +47,7 @@ sh_test(
     args = [
         "$(location :executable_installer_under_test)",
         "$(location testdata/executable.exe)",
+        "-executable=True",
     ],
     data = [
         "testdata/executable.exe",
@@ -55,6 +58,7 @@ sh_test(
 installer(
     name = "subdir_installer_under_test",
     data = ["testdata/data.txt"],
+    executable = False,
     target_subdir = "docs",
 )
 
@@ -64,7 +68,8 @@ sh_test(
     args = [
         "$(location :subdir_installer_under_test)",
         "$(location testdata/data.txt)",
-        "docs",
+        "-subdir=docs",
+        "-executable=False",
     ],
     data = [
         "testdata/data.txt",
@@ -79,6 +84,7 @@ installer(
         "testdata/executable.exe",
         "testdata/subdir/subdir_data.txt",
     ],
+    executable = False,
 )
 
 # Test each result separately
@@ -88,6 +94,7 @@ sh_test(
     args = [
         "$(location :multifile_installer_under_test)",
         "$(location testdata/data.txt)",
+        "-executable=False",
     ],
     data = [
         "testdata/data.txt",
@@ -101,6 +108,8 @@ sh_test(
     args = [
         "$(location :multifile_installer_under_test)",
         "$(location testdata/executable.exe)",
+        # At the moment the multifile installer can't mix modes.
+        "-executable=False",
     ],
     data = [
         "testdata/executable.exe",
@@ -114,6 +123,7 @@ sh_test(
     args = [
         "$(location :multifile_installer_under_test)",
         "$(location testdata/subdir/subdir_data.txt)",
+        "-executable=False",
     ],
     data = [
         "testdata/subdir/subdir_data.txt",


### PR DESCRIPTION
Set it to True (default) if the installed file is an executable.