### PR TITLE
Use a config transition to set compilation_mode to "opt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Run the `installer` using `bazel run`. The following example installs `foo` in
 `~/bin`:
 
 ```shell
-bazel run //src/path/to/pkg:install_foo -c opt -- ~/bin
+bazel run //src/path/to/pkg:install_foo -- ~/bin
 ```
 
 ### sudo
@@ -79,8 +79,32 @@ If you need to use `sudo` to install a file in a system directory:
 * Instead pass flag `-s` to the installer.
 
 ```shell
-bazel run //src/path/to/pkg:install_foo -c opt -- -s /usr/local/bin
+bazel run //src/path/to/pkg:install_foo -- -s /usr/local/bin
 ```
+
+### Debug builds
+
+By default `installer` uses targets built with `-c opt`. To disable this
+override of a command line flag use `compilation_mode = ""` attribute:
+
+```python
+installer(
+    name = "install_foo",
+    compilation_mode = "",
+    data = [":foo"],
+)
+```
+
+Alternatively you can force a debug build:
+
+```python
+installer(
+    name = "install_foo_dbg",
+    compilation_mode = "dbg",
+    data = [":foo"],
+)
+```
+
 
 ## See also
 

--- a/docs/WORKSPACE
+++ b/docs/WORKSPACE
@@ -23,8 +23,9 @@ local_repository(
 
 git_repository(
     name = "io_bazel_stardoc",
+    commit = "4378e9b6bb2831de7143580594782f538f461180",  # 0.4.0
     remote = "https://github.com/bazelbuild/stardoc.git",
-    commit = "4378e9b6bb2831de7143580594782f538f461180", # 0.4.0
+    shallow_since = "1570829166 -0400",
 )
 
 load("@com_github_google_rules_install//:deps.bzl", "install_rules_dependencies")

--- a/docs/installer_rule.md
+++ b/docs/installer_rule.md
@@ -5,7 +5,7 @@
 ## installer
 
 <pre>
-installer(<a href="#installer-name">name</a>, <a href="#installer-data">data</a>, <a href="#installer-executable">executable</a>, <a href="#installer-target_subdir">target_subdir</a>)
+installer(<a href="#installer-name">name</a>, <a href="#installer-data">data</a>, <a href="#installer-compilation_mode">compilation_mode</a>, <a href="#installer-executable">executable</a>, <a href="#installer-target_subdir">target_subdir</a>)
 </pre>
 
 Creates an installer
@@ -22,7 +22,8 @@ argument to the installer.
 | :-------------: | :-------------: | :-------------: |
 | name |  A unique name of this rule.   |  none |
 | data |  Targets to be installed. File names will not be changed.   |  none |
-| executable |  If True (default), the copied files will be set as executable.   |  <code>True</code> |
+| compilation_mode |  If not empty, sets compilation_mode of targets in data.   |  <code>"opt"</code> |
+| executable |  If True, the copied files will be set as executable.   |  <code>True</code> |
 | target_subdir |  Optional subdir under the prefix where the files will be                placed.   |  <code>""</code> |
 
 

--- a/installer/BUILD.bazel
+++ b/installer/BUILD.bazel
@@ -32,9 +32,9 @@ bzl_library(
     srcs = [
         "def.bzl",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/installer/installer.bash.template
+++ b/installer/installer.bash.template
@@ -17,13 +17,10 @@
 #
 @@GENERATED_WARNING@@ ; exit 1
 #
-# 1.  To use this template, add installer() rule from install/installer.bzl
+# 1.  To use this template, add installer() rule from installer/def.bzl
 #     to your BUILD file.
 # 2.  To install the target under /usr/local/bin, run:
-#     bazel run //path/to/your:installer_target -c opt /usr/local/bin
-#
-#     If you don't want --compilation_mode=opt, run:
-#     bazel run //path/to/your:installer_target -- -g /usr/local/bin
+#     bazel run //path/to/your:installer_target -- /usr/local/bin
 #
 #     To use sudo, run:
 #     bazel run //path/to/your:installer_target -- -s /usr/local/bin
@@ -35,8 +32,6 @@ set -o pipefail -o errexit -o nounset
 declare -r -a SOURCE_FILES=@@SOURCE_FILES@@
 # Array of paths relative to prefix.
 declare -r -a TARGET_NAMES=@@TARGET_NAMES@@
-# Value for the -c or --compilation_mode bazel var.
-declare -r COMPILATION_MODE=@@COMPILATION_MODE@@
 # Set executable mode of files
 declare -r EXECUTABLE=@@EXECUTABLE@@
 # Fully specified bazel label of INSTALLER_LABEL installer() rule.
@@ -51,14 +46,13 @@ function error() {
 }
 
 function usage() {
-  echo >&2 "Usage: bazel run ${INSTALLER_LABEL} [-c opt] [--] [-g] [-s] [--] /INSTALL_PREFIX"
+  echo >&2 "Usage: bazel run ${INSTALLER_LABEL} [-c opt] [--] [-s] [--] /INSTALL_PREFIX"
 }
 
 # Checks that all template variables have been substituted.
 function verify_templates() {
   if [[ "${SOURCE_FILES[@]:0:2}" =~ ^@@ ]] ||
     [[ "${TARGET_NAMES[@]:0:2}" =~ ^@@ ]] ||
-    [[ "${COMPILATION_MODE:0:2}" =~ ^@@ ]] ||
     [[ "${INSTALLER_LABEL:0:2}" =~ ^@@ ]]; then
     error "template substitution failed"
   fi
@@ -109,16 +103,12 @@ function main() {
   local s_flag=''
   while getopts ':ghs' flag; do
     case "${flag}" in
-      g) g_flag='true' ;;  # Accept debug builds
+      g) g_flag='' ;;  # Ignored - debug builds flag
       s) s_flag='sudo' ;;  # Run with sudo
       h) usage; exit 0 ;;
       *) error "Unexpected option '-${OPTARG}'"   ;;
     esac
   done
-
-  if [[ "${g_flag}" != 'true' ]] && [[ "${COMPILATION_MODE}" != 'opt' ]]; then
-    error "run bazel with '-c opt' or add '-- -g' option to run installer ${g_flag}"
-  fi
 
   if [[ -z "${OPTIND:-}" ]] || (($OPTIND > $#)); then
     error "INSTALL_PREFIX wasn't specified"

--- a/scripts/run_buildifier.sh
+++ b/scripts/run_buildifier.sh
@@ -19,15 +19,20 @@ set -eu
 # -------------------------------------------------------------------------
 # Asked to do a buildifier run.
 if [[ -z "${RUN_BUILDIFIER:-}" ]]; then
-  echo >&2 "Skipping buildifier"
+  echo >&2 'Skipping buildifier'
 else
   if ! diff -u <(git status --porcelain=v2) /dev/null; then
-    echo >&2 "Repository is not in a clean state"
+    echo >&2 'Repository is not in a clean state'
     exit 1
   fi
 
   if ! bazel run  --show_progress_rate_limit=30.0 :buildifier -- --mode=check; then
-    echo >&2 "Run `bazel run :buildifier`"
+    echo >&2 'Run `bazel run :buildifier`'
+    exit 1
+  fi
+
+  if ! diff -u <(git status --porcelain=v2) /dev/null; then
+    echo >&2 'You need to `bazel run //:buildifier`'
     exit 1
   fi
 fi

--- a/tests/installer_test.sh
+++ b/tests/installer_test.sh
@@ -86,7 +86,7 @@ function verify_install() {
 function test_basic_install() {
   local tmpdir="$1"
 
-  if ! "${INSTALLER}" -g "${tmpdir}"; then
+  if ! "${INSTALLER}" "${tmpdir}"; then
     echo >&2 "installer didn't exit with code 0"
     return 1
   fi
@@ -104,7 +104,7 @@ function test_basic_install() {
 function test_prefix_install() {
   local tmpdir="$1"
 
-  if ! "${INSTALLER}" -g "${tmpdir}/a/b/c"; then
+  if ! "${INSTALLER}" "${tmpdir}/a/b/c"; then
     echo >&2 "installer didn't exit with code 0"
     return 1
   fi


### PR DESCRIPTION
installer() rule by default depends now on targets built with '-c opt'

To disable this override of a command line flag use `compilation_mode = ""`
attribute:

```
installer(
    name = "install_foo",
    compilation_mode = "",
    data = [":foo"],
)
```

Alternatively you can force a debug build:

```
installer(
    name = "install_foo_dbg",
    compilation_mode = "dbg",
    data = [":foo"],
)
```