### PR TITLE
Install both default_runfiles and files_to_run

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -130,3 +130,45 @@ sh_test(
         ":multifile_installer_under_test",
     ],
 )
+
+installer(
+    name = "filegroup_installer_under_test",
+    data = [":test_filegroup"],
+    executable = False,
+)
+
+filegroup(
+    name = "test_filegroup",
+    data = [
+        "testdata/data.txt",
+        "testdata/subdir/subdir_data.txt",
+    ],
+)
+
+sh_test(
+    name = "filegroup_installer_test_1",
+    srcs = ["installer_test.sh"],
+    args = [
+        "$(location :filegroup_installer_under_test)",
+        "$(location testdata/subdir/subdir_data.txt)",
+        "-executable=False",
+    ],
+    data = [
+        "testdata/subdir/subdir_data.txt",
+        ":filegroup_installer_under_test",
+    ],
+)
+
+sh_test(
+    name = "filegroup_installer_test_2",
+    srcs = ["installer_test.sh"],
+    args = [
+        "$(location :filegroup_installer_under_test)",
+        "$(location testdata/data.txt)",
+        "-executable=False",
+    ],
+    data = [
+        "testdata/data.txt",
+        ":filegroup_installer_under_test",
+    ],
+)

--- a/tests/installer_test.sh
+++ b/tests/installer_test.sh
@@ -32,7 +32,7 @@ while (( "$#" >  2 )); do
       declare -r SUBDIR="${3#-subdir=}"
     ;;
     -executable=*)
-      # target_subdir attribute of installer rule
+      # executable attribute of installer rule
       declare -r EXECUTABLE="${3#-executable=}"
     ;;
     *)


### PR DESCRIPTION
Previously installer used only the FilesToRunProvider.executable
Now it also uses DefaultInfo.default_runfiles, which should make
filegroups behave as expected.

Fixes #24