### PR TITLE
use /usr/bin/env to find bash

### DIFF
--- a/docs/regen.sh
+++ b/docs/regen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/installer/installer.bash.template
+++ b/installer/installer.bash.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/scripts/run_buildifier.sh
+++ b/scripts/run_buildifier.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/scripts/run_regen_docs.sh
+++ b/scripts/run_regen_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/tests/installer_test.sh
+++ b/tests/installer_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/testdata/executable.exe
+++ b/tests/testdata/executable.exe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors.
 # SPDX-License-Identifier: Apache-2.0
 echo "Hello, world!"


### PR DESCRIPTION
This makes it work on NixOS, which does not have /bin/bash. [1]

[1]: https://discourse.nixos.org/t/add-bin-bash-to-avoid-unnecessary-pain/5673