### PR TITLE
Fixed installer for generated files on Windows

### DIFF
--- a/installer/def.bzl
+++ b/installer/def.bzl
@@ -51,6 +51,10 @@ def _gen_install_binary_impl(ctx):
 
         for file in input_files.to_list():
             file_path = file.path
+            root_path = file.root.path + "/"
+
+            if file_path.startswith(root_path):
+                file_path = file_path[len(root_path):]
 
             if file_path.startswith(external_prefix):
                 file_path = file_path[len(external_prefix):]

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -77,6 +77,32 @@ sh_test(
     ],
 )
 
+genrule(
+    name = "generate_test",
+    outs = ["generated_file.txt"],
+    cmd = "echo this is a test file > $@",
+)
+
+installer(
+    name = "generated_file_installer_under_test",
+    data = ["generated_file.txt"],
+    executable = False,
+)
+
+sh_test(
+    name = "generated_file_installer_test",
+    srcs = ["installer_test.sh"],
+    args = [
+        "$(location :generated_file_installer_under_test)",
+        "$(location generated_file.txt)",
+        "-executable=False",
+    ],
+    data = [
+        "generated_file.txt",
+        ":generated_file_installer_under_test",
+    ],
+)
+
 installer(
     name = "multifile_installer_under_test",
     data = [

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -78,14 +78,14 @@ sh_test(
 )
 
 genrule(
-    name = "generate_test",
+    name = "generated_file",
     outs = ["generated_file.txt"],
     cmd = "echo this is a test file > $@",
 )
 
 installer(
     name = "generated_file_installer_under_test",
-    data = ["generated_file.txt"],
+    data = [":generated_file"],
     executable = False,
 )
 
@@ -94,11 +94,11 @@ sh_test(
     srcs = ["installer_test.sh"],
     args = [
         "$(location :generated_file_installer_under_test)",
-        "$(location generated_file.txt)",
+        "$(location :generated_file)",
         "-executable=False",
     ],
     data = [
-        "generated_file.txt",
+        ":generated_file",
         ":generated_file_installer_under_test",
     ],
 )

--- a/tests/test_workspace/BUILD.bazel
+++ b/tests/test_workspace/BUILD.bazel
@@ -19,10 +19,17 @@ exports_files([
     "subdir/subdir_data.txt",
 ])
 
+genrule(
+    name = "generate_test",
+    outs = ["generated_file.txt"],
+    cmd = "echo this is a test file > $@",
+)
+
 filegroup(
     name = "test_filegroup",
     data = [
         "data_from_another_workspace.txt",
+        "generated_file.txt",
         "subdir/subdir_data.txt",
     ],
     visibility = ["//visibility:public"],

--- a/tests/test_workspace/BUILD.bazel
+++ b/tests/test_workspace/BUILD.bazel
@@ -20,7 +20,7 @@ exports_files([
 ])
 
 genrule(
-    name = "generate_test",
+    name = "generated_file",
     outs = ["generated_file.txt"],
     cmd = "echo this is a test file > $@",
 )
@@ -29,8 +29,8 @@ filegroup(
     name = "test_filegroup",
     data = [
         "data_from_another_workspace.txt",
-        "generated_file.txt",
         "subdir/subdir_data.txt",
+        ":generated_file",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Installer would fail if the file was generated by bazel on Windows.

A generated file was added to the testsuite and a fix was implemented