### PR TITLE
Use 'install -m' instead of 'install --mode'

### DIFF
--- a/installer/installer.bash.template
+++ b/installer/installer.bash.template
@@ -103,7 +103,7 @@ function install_file() {
   [[ -d "${target_dir}" ]] || \
     $sudo mkdir --parents -- "${target_dir}"
 
-  $sudo install --mode="${target_mode}" \
+  $sudo install -m "${target_mode}" \
     -T -- "${source}" "${target_dir}/${target_name}"
 }
 


### PR DESCRIPTION
The implementation of install on FreeBSD does not support long
option names

Signed-off-by: Doug Rabson <dfr@rabson.org>