### PR TITLE
macOS support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,8 +7,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -21,7 +25,7 @@ jobs:
             ~/.cache/bazel
           key: ${{ runner.os }}-bazel-cache
 
-      - name: Bazel on Linux
+      - name: Bazel on ${{ matrix.os }}
         run: |
           set -x -e
           bash -x -e scripts/run_buildifier.sh

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -27,6 +27,7 @@ install_rules_dependencies()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
+    sha256 = "e3bb0dc8b0274ea1aca75f1f8c0c835adbe589708ea89bf698069d0790701ea3",
     strip_prefix = "buildtools-5.1.0",
     urls = [
         "https://github.com/bazelbuild/buildtools/archive/refs/tags/5.1.0.tar.gz",

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -18,7 +18,11 @@ set -eu
 
 cd "$(dirname "$0")"
 
-declare -r tmpdir="$(mktemp -d)"
+if ! [[ -z "${RUNNER_TEMP:-}" ]]; then
+  declare -r tmpdir="$RUNNER_TEMP"
+else
+  declare -r tmpdir="$(mktemp -d)"
+fi
 
 bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier "${tmpdir}"
 "${tmpdir}/buildifier" --version

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -xeu
 
 cd "$(dirname "$0")"
 

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -27,7 +27,7 @@ fi
 
 ls -alh "${installdir}"
 
-bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier "${installdir}"
+bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier -- "${installdir}"
 "${installdir}/buildifier" --version
 
 rm -rf "${installdir}"

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -18,15 +18,16 @@ set -eu
 
 cd "$(dirname "$0")"
 
-if ! [[ -z "${RUNNER_TEMP:-}" ]]; then
-  declare -r tmpdir="$RUNNER_TEMP"
+if [[ "${CI:-false}" = "true" ]]; then
+  declare -r installdir="${GITHUB_WORKSPACE}/testinstall"
+  mkdir -p "${installdir}"
 else
-  declare -r tmpdir="$(mktemp -d)"
+  declare -r installdir="$(mktemp -d)"
 fi
 
-ls -alh "${tmpdir}"
+ls -alh "${installdir}"
 
-bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier "${tmpdir}"
-"${tmpdir}/buildifier" --version
+bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier "${installdir}"
+"${installdir}/buildifier" --version
 
-rm -rf "${tmpdir}"
+rm -rf "${installdir}"

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -24,6 +24,8 @@ else
   declare -r tmpdir="$(mktemp -d)"
 fi
 
+ls -alh "${tmpdir}"
+
 bazel run  --show_progress_rate_limit=30.0 -c opt :install_buildifier "${tmpdir}"
 "${tmpdir}/buildifier" --version
 

--- a/installer/installer.bash.template
+++ b/installer/installer.bash.template
@@ -82,6 +82,13 @@ function check_sources() {
   done
 }
 
+function beginswith() {
+  case $2 in
+    "$1"*) true;;
+    *) false;;
+  esac
+}
+
 # Installs $i-th file in $prefix.
 function install_file() {
   local prefix="$1"
@@ -101,10 +108,16 @@ function install_file() {
   fi
 
   [[ -d "${target_dir}" ]] || \
-    $sudo mkdir --parents -- "${target_dir}"
+    $sudo mkdir -p "${target_dir}"
 
-  $sudo install -m "${target_mode}" \
-    -T -- "${source}" "${target_dir}/${target_name}"
+  if [[ "$(uname -s)" = "Darwin" ]]; then
+    # Darwin doesn't support `-T` or `--`.
+    $sudo install -m "${target_mode}" \
+      "${source}" "${target_dir}/${target_name}"
+  else
+    $sudo install -m "${target_mode}" \
+      -T -- "${source}" "${target_dir}/${target_name}"
+  fi
 }
 
 function main() {


### PR DESCRIPTION
Sadly macOS binutils are similar but different:

For example the `install` tool on macOS does not support using `--` to separate options from positional arguments. This PR checks if the source starts with `-` and skips the `--` if not required.

Please note I would happy to edit this PR to implements another way of skipping the `--`. Maybe checking if we are on darwin or something else. Open to suggestions !

This PR also adapts the test script to support macOS, and adds a macOS workflow to the test github actions.